### PR TITLE
Update Dockerfile for improved stability and compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:lts-alpine
 WORKDIR /gitcol-learning
 COPY . /gitcol-learning
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts-slim
 WORKDIR /gitcol-learning
 COPY . /gitcol-learning
 RUN npm install


### PR DESCRIPTION
Switch the base image in the Dockerfile to `node:lts-slim` for better compatibility while maintaining stability.