### PR TITLE
Fix URL construction in startAloneMode function

### DIFF
--- a/src/view/dist/js/dialogs/dialog-single-home-script.js
+++ b/src/view/dist/js/dialogs/dialog-single-home-script.js
@@ -1,5 +1,5 @@
 const startAloneMode = async (mode) => {
-	const url = new URL(window.location.href + "aloneMode/" + mode);
+	const url = new URL(window.location.origin + "/aloneMode/" + mode);
 	window.location.href = url.toString();
 };
 const openDialogSingle = async () => {


### PR DESCRIPTION
Correct the URL construction to use `window.location.origin` instead of `window.location.href` for better accuracy in navigating to the alone mode.